### PR TITLE
cisst-ros: add more data conversion types: int32, mtsFrm4x4

### DIFF
--- a/cisst_ros_bridge/include/cisst_ros_bridge/mtsCISSTToROS.h
+++ b/cisst_ros_bridge/include/cisst_ros_bridge/mtsCISSTToROS.h
@@ -31,11 +31,13 @@ http://www.cisst.org/cisst/license.txt.
 #include <cisstParameterTypes/prmFixtureGainCartesianSet.h>
 
 #include <cisstMultiTask/mtsVector.h>
+#include <cisstMultiTask/mtsTransformationTypes.h>
 
 // ros include
 #include <ros/ros.h>
 #include <std_msgs/Float32.h>
 #include <std_msgs/Bool.h>
+#include <std_msgs/Int32.h>
 #include <std_msgs/String.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/WrenchStamped.h>
@@ -53,6 +55,7 @@ http://www.cisst.org/cisst/license.txt.
 
 // std_msgs
 void mtsCISSTToROS(const double & cisstData, std_msgs::Float32 & rosData);
+void mtsCISSTToROS(const int & cisstData, std_msgs::Int32 & rosData);
 void mtsCISSTToROS(const bool & cisstData, std_msgs::Bool & rosData);
 void mtsCISSTToROS(const std::string & cisstData, std_msgs::String & rosData);
 void mtsCISSTToROS(const prmEventButton & cisstData, std_msgs::Bool & rosData);
@@ -62,7 +65,11 @@ void mtsCISSTToROS(const prmPositionCartesianGet & cisstData, geometry_msgs::Tra
 void mtsCISSTToROS(const prmPositionCartesianGet & cisstData, geometry_msgs::Pose & rosData);
 void mtsCISSTToROS(const prmPositionCartesianGet & cisstData, geometry_msgs::PoseStamped & rosData);
 void mtsCISSTToROS(const vctFrm4x4 & cisstData, geometry_msgs::Pose & rosData);
+void mtsCISSTToROS(const mtsFrm4x4 & cisstData, geometry_msgs::Pose & rosData);
 void mtsCISSTToROS(const vctFrm3 & cisstData, geometry_msgs::Pose & rosData);
+void mtsCISSTToROS(const vctFrm4x4 & cisstData, geometry_msgs::Transform & rosData);
+void mtsCISSTToROS(const mtsFrm4x4 & cisstData, geometry_msgs::Transform & rosData);
+void mtsCISSTToROS(const vctFrm3 & cisstData, geometry_msgs::Transform & rosData);
 void mtsCISSTToROS(const vct3 & cisstData, geometry_msgs::Vector3 & rosData);
 void mtsCISSTToROS(const vctMatRot3 & cisstData, geometry_msgs::Quaternion & rosData);
 void mtsCISSTToROS(const mtsDoubleVec & cisstData, geometry_msgs::Wrench & rosData);

--- a/cisst_ros_bridge/include/cisst_ros_bridge/mtsROSToCISST.h
+++ b/cisst_ros_bridge/include/cisst_ros_bridge/mtsROSToCISST.h
@@ -22,6 +22,7 @@ http://www.cisst.org/cisst/license.txt.
 
 // cisst include
 #include <cisstVector/vctDynamicVectorTypes.h>
+#include <cisstMultiTask/mtsTransformationTypes.h>
 #include <cisstParameterTypes/prmPositionCartesianGet.h>
 #include <cisstParameterTypes/prmPositionCartesianSet.h>
 #include <cisstParameterTypes/prmPositionJointGet.h>
@@ -34,6 +35,7 @@ http://www.cisst.org/cisst/license.txt.
 #include <ros/ros.h>
 #include <std_msgs/Float32.h>
 #include <std_msgs/Bool.h>
+#include <std_msgs/Int32.h>
 #include <std_msgs/String.h>
 
 #include <geometry_msgs/TransformStamped.h>
@@ -48,6 +50,7 @@ http://www.cisst.org/cisst/license.txt.
 
 // std_msgs
 void mtsROSToCISST(const std_msgs::Float32 & rosData, double & cisstData);
+void mtsROSToCISST(const std_msgs::Int32 & rosData, int & cisstData);
 void mtsROSToCISST(const std_msgs::Bool & rosData, bool & cisstData);
 void mtsROSToCISST(const std_msgs::String & rosData, std::string & cisstData);
 
@@ -57,9 +60,13 @@ void mtsROSToCISST(const geometry_msgs::Quaternion & rosData, vctMatRot3 & cisst
 void mtsROSToCISST(const geometry_msgs::Pose & rosData, prmPositionCartesianGet & cisstData);
 void mtsROSToCISST(const geometry_msgs::Pose & rosData, prmPositionCartesianSet & cisstData);
 void mtsROSToCISST(const geometry_msgs::PoseStamped & rosData, prmPositionCartesianSet & cisstData);
+void mtsROSToCISST(const geometry_msgs::Pose & rosData, vctFrm3 & cisstData);
 void mtsROSToCISST(const geometry_msgs::Pose & rosData, vctFrm4x4 & cisstData);
+void mtsROSToCISST(const geometry_msgs::Pose & rosData, mtsFrm4x4 & cisstData);
 void mtsROSToCISST(const geometry_msgs::Transform & rosData, prmPositionCartesianGet & cisstData);
+void mtsROSToCISST(const geometry_msgs::Transform & rosData, vctFrm3 & cisstData);
 void mtsROSToCISST(const geometry_msgs::Transform & rosData, vctFrm4x4 & cisstData);
+void mtsROSToCISST(const geometry_msgs::Transform & rosData, mtsFrm4x4 & cisstData);
 void mtsROSToCISST(const geometry_msgs::Wrench & rosData, prmForceCartesianSet & cisstData);
 void mtsROSToCISST(const geometry_msgs::WrenchStamped & rosData, prmForceCartesianSet & cisstData);
 

--- a/cisst_ros_bridge/src/mtsCISSTToROS.cpp
+++ b/cisst_ros_bridge/src/mtsCISSTToROS.cpp
@@ -23,6 +23,11 @@ void mtsCISSTToROS(const double & cisstData, std_msgs::Float32 & rosData)
     rosData.data = cisstData;
 }
 
+void mtsCISSTToROS(const int & cisstData, std_msgs::Int32 & rosData)
+{
+    rosData.data = cisstData;
+}
+
 void mtsCISSTToROS(const bool & cisstData, std_msgs::Bool & rosData)
 {
     rosData.data = cisstData;
@@ -84,6 +89,19 @@ void mtsCISSTToROS(const vctFrm4x4 & cisstData, geometry_msgs::Pose & rosData)
     rosData.position.z = cisstData.Translation().Z();
 }
 
+void mtsCISSTToROS(const mtsFrm4x4 & cisstData, geometry_msgs::Pose & rosData)
+{
+    vctQuatRot3 quat(cisstData.Rotation(), VCT_NORMALIZE);
+    rosData.orientation.x = quat.X();
+    rosData.orientation.y = quat.Y();
+    rosData.orientation.z = quat.Z();
+    rosData.orientation.w = quat.W();
+    rosData.position.x = cisstData.Translation().X();
+    rosData.position.y = cisstData.Translation().Y();
+    rosData.position.z = cisstData.Translation().Z();
+}
+
+
 void mtsCISSTToROS(const vctFrm3 & cisstData, geometry_msgs::Pose & rosData)
 {
     vctQuatRot3 quat(cisstData.Rotation(), VCT_NORMALIZE);
@@ -94,6 +112,40 @@ void mtsCISSTToROS(const vctFrm3 & cisstData, geometry_msgs::Pose & rosData)
     rosData.position.x = cisstData.Translation().X();
     rosData.position.y = cisstData.Translation().Y();
     rosData.position.z = cisstData.Translation().Z();
+}
+
+void mtsCISSTToROS(const vctFrm4x4 & cisstData, geometry_msgs::Transform & rosData)
+{
+    vctQuatRot3 quat(cisstData.Rotation(), VCT_NORMALIZE);
+    rosData.rotation.x = quat.X();
+    rosData.rotation.y = quat.Y();
+    rosData.rotation.z = quat.Z();
+    rosData.rotation.w = quat.W();
+    rosData.translation.x = cisstData.Translation().X();
+    rosData.translation.y = cisstData.Translation().Y();
+    rosData.translation.z = cisstData.Translation().Z();
+}
+void mtsCISSTToROS(const mtsFrm4x4 & cisstData, geometry_msgs::Transform & rosData)
+{
+    vctQuatRot3 quat(cisstData.Rotation(), VCT_NORMALIZE);
+    rosData.rotation.x = quat.X();
+    rosData.rotation.y = quat.Y();
+    rosData.rotation.z = quat.Z();
+    rosData.rotation.w = quat.W();
+    rosData.translation.x = cisstData.Translation().X();
+    rosData.translation.y = cisstData.Translation().Y();
+    rosData.translation.z = cisstData.Translation().Z();
+}
+void mtsCISSTToROS(const vctFrm3 & cisstData, geometry_msgs::Transform & rosData)
+{
+    vctQuatRot3 quat(cisstData.Rotation(), VCT_NORMALIZE);
+    rosData.rotation.x = quat.X();
+    rosData.rotation.y = quat.Y();
+    rosData.rotation.z = quat.Z();
+    rosData.rotation.w = quat.W();
+    rosData.translation.x = cisstData.Translation().X();
+    rosData.translation.y = cisstData.Translation().Y();
+    rosData.translation.z = cisstData.Translation().Z();
 }
 
 void mtsCISSTToROS(const vct3 & cisstData, geometry_msgs::Vector3 & rosData)

--- a/cisst_ros_bridge/src/mtsROSToCISST.cpp
+++ b/cisst_ros_bridge/src/mtsROSToCISST.cpp
@@ -24,6 +24,11 @@ void mtsROSToCISST(const std_msgs::Float32 & rosData, double & cisstData)
     cisstData = rosData.data;
 }
 
+void mtsROSToCISST(const std_msgs::Int32 & rosData, int & cisstData)
+{
+    cisstData = rosData.data;
+}
+
 void mtsROSToCISST(const std_msgs::Bool & rosData, bool & cisstData)
 {
     cisstData = rosData.data;
@@ -84,8 +89,35 @@ void mtsROSToCISST(const geometry_msgs::PoseStamped & rosData, prmPositionCartes
 {
     mtsROSToCISST(rosData.pose, cisstData);
 }
+void mtsROSToCISST(const geometry_msgs::Pose & rosData, vctFrm3 & cisstData)
+{
+    cisstData.Translation().X() = rosData.position.x;
+    cisstData.Translation().Y() = rosData.position.y;
+    cisstData.Translation().Z() = rosData.position.z;
+    vctQuatRot3 quat;
+    quat.X() = rosData.orientation.x;
+    quat.Y() = rosData.orientation.y;
+    quat.Z() = rosData.orientation.z;
+    quat.W() = rosData.orientation.w;
+    vctMatRot3 rotation(quat, VCT_NORMALIZE);
+    cisstData.Rotation().Assign(rotation);
+}
 
 void mtsROSToCISST(const geometry_msgs::Pose & rosData, vctFrm4x4 & cisstData)
+{
+    cisstData.Translation().X() = rosData.position.x;
+    cisstData.Translation().Y() = rosData.position.y;
+    cisstData.Translation().Z() = rosData.position.z;
+    vctQuatRot3 quat;
+    quat.X() = rosData.orientation.x;
+    quat.Y() = rosData.orientation.y;
+    quat.Z() = rosData.orientation.z;
+    quat.W() = rosData.orientation.w;
+    vctMatRot3 rotation(quat, VCT_NORMALIZE);
+    cisstData.Rotation().Assign(rotation);
+}
+
+void mtsROSToCISST(const geometry_msgs::Pose & rosData, mtsFrm4x4 & cisstData)
 {
     cisstData.Translation().X() = rosData.position.x;
     cisstData.Translation().Y() = rosData.position.y;
@@ -112,8 +144,35 @@ void mtsROSToCISST(const geometry_msgs::Transform & rosData, prmPositionCartesia
     vctMatRot3 rotation(quat, VCT_NORMALIZE);
     cisstData.Position().Rotation().Assign(rotation);
 }
+void mtsROSToCISST(const geometry_msgs::Transform & rosData, vctFrm3 & cisstData)
+{
+    cisstData.Translation().X() = rosData.translation.x;
+    cisstData.Translation().Y() = rosData.translation.y;
+    cisstData.Translation().Z() = rosData.translation.z;
+    vctQuatRot3 quat;
+    quat.X() = rosData.rotation.x;
+    quat.Y() = rosData.rotation.y;
+    quat.Z() = rosData.rotation.z;
+    quat.W() = rosData.rotation.w;
+    vctMatRot3 rotation(quat, VCT_NORMALIZE);
+    cisstData.Rotation().FromNormalized(rotation);
+}
 
 void mtsROSToCISST(const geometry_msgs::Transform & rosData, vctFrm4x4 & cisstData)
+{
+    cisstData.Translation().X() = rosData.translation.x;
+    cisstData.Translation().Y() = rosData.translation.y;
+    cisstData.Translation().Z() = rosData.translation.z;
+    vctQuatRot3 quat;
+    quat.X() = rosData.rotation.x;
+    quat.Y() = rosData.rotation.y;
+    quat.Z() = rosData.rotation.z;
+    quat.W() = rosData.rotation.w;
+    vctMatRot3 rotation(quat, VCT_NORMALIZE);
+    cisstData.Rotation().FromNormalized(rotation);
+}
+
+void mtsROSToCISST(const geometry_msgs::Transform & rosData, mtsFrm4x4 & cisstData)
 {
     cisstData.Translation().X() = rosData.translation.x;
     cisstData.Translation().Y() = rosData.translation.y;


### PR DESCRIPTION
Refactoring repeated conversion would also be useful:

```c++
//this snipped is used many times
vctQuatRot3 quat(cisstData.Rotation(), VCT_NORMALIZE);
rosData.orientation.x = quat.X();
rosData.orientation.y = quat.Y();
rosData.orientation.z = quat.Z();
rosData.orientation.w = quat.W();
rosData.position.x = cisstData.Translation().X();
rosData.position.y = cisstData.Translation().Y();
rosData.position.z = cisstData.Translation().Z();
```