### PR TITLE
fix req bridge connect and add servo_jv support

### DIFF
--- a/cisst_ros_bridge/include/cisst_ros_bridge/mtsCISSTToROS.h
+++ b/cisst_ros_bridge/include/cisst_ros_bridge/mtsCISSTToROS.h
@@ -31,6 +31,7 @@ http://www.cisst.org/cisst/license.txt.
 #include <cisstParameterTypes/prmPositionJointGet.h>
 #include <cisstParameterTypes/prmPositionJointSet.h>
 #include <cisstParameterTypes/prmVelocityJointGet.h>
+#include <cisstParameterTypes/prmVelocityJointSet.h>
 #include <cisstParameterTypes/prmForceTorqueJointSet.h>
 #include <cisstParameterTypes/prmStateJoint.h>
 #include <cisstParameterTypes/prmPositionCartesianGet.h>
@@ -200,6 +201,7 @@ bool mtsCISSTToROS(const vctDoubleVec & cisstData, sensor_msgs::JointState & ros
 bool mtsCISSTToROS(const prmPositionJointGet & cisstData, sensor_msgs::JointState & rosData, const std::string & debugInfo);
 bool mtsCISSTToROS(const prmPositionJointSet & cisstData, sensor_msgs::JointState & rosData, const std::string & debugInfo);
 bool mtsCISSTToROS(const prmVelocityJointGet & cisstData, sensor_msgs::JointState & rosData, const std::string & debugInfo);
+bool mtsCISSTToROS(const prmVelocityJointSet & cisstData, sensor_msgs::JointState & rosData, const std::string & debugInfo);
 bool mtsCISSTToROS(const prmForceTorqueJointSet & cisstData, sensor_msgs::JointState & rosData, const std::string & debugInfo);
 bool mtsCISSTToROS(const prmStateJoint & cisstData, sensor_msgs::JointState & rosData, const std::string & debugInfo);
 bool mtsCISSTToROS(const vctDoubleMat & cisstData, sensor_msgs::PointCloud & rosData, const std::string & debugInfo);

--- a/cisst_ros_bridge/src/mtsCISSTToROS.cpp
+++ b/cisst_ros_bridge/src/mtsCISSTToROS.cpp
@@ -545,6 +545,23 @@ bool mtsCISSTToROS(const prmVelocityJointGet & cisstData, sensor_msgs::JointStat
     return false;
 }
 
+bool mtsCISSTToROS(const prmVelocityJointSet & cisstData, sensor_msgs::JointState & rosData,
+                   const std::string & debugInfo)
+{
+    if (mtsCISSTToROSHeader(cisstData, rosData, debugInfo)) {
+        rosData.name.resize(0);
+        rosData.effort.resize(0);
+        const size_t size = cisstData.Goal().size();
+        if (size != 0) {
+            rosData.velocity.resize(size);
+            std::copy(cisstData.Goal().begin(), cisstData.Goal().end(),
+                      rosData.velocity.begin());
+        }
+        return true;
+    }
+    return false;
+}
+
 bool mtsCISSTToROS(const prmForceTorqueJointSet & cisstData, sensor_msgs::JointState & rosData,
                    const std::string & debugInfo)
 {

--- a/cisst_ros_crtk/src/mts_ros_crtk_bridge_required.cpp
+++ b/cisst_ros_crtk/src/mts_ros_crtk_bridge_required.cpp
@@ -106,6 +106,8 @@ void mts_ros_crtk_bridge_required::bridge_interface_required(const std::string &
                                 _interface_required->GetNamesOfFunctionsWrite(),
                                 _interface_required->GetNamesOfFunctionsRead(),
                                 _interface_required->GetNamesOfEventHandlersWrite());
+    m_connections.Add(this->GetName(), _provided_interface_name,
+                      _component_name, _interface_name);
 }
 
 void mts_ros_crtk_bridge_required::populate_interface_provided(const std::string & _interface_name,
@@ -139,6 +141,9 @@ void mts_ros_crtk_bridge_required::populate_interface_provided(const std::string
             || (_crtk_command == "move_jp")
             || (_crtk_command == "move_jr")) {
             this->AddPublisherFromCommandWrite<prmPositionJointSet, sensor_msgs::JointState>
+                (_interface_name, _command, _ros_topic);
+        } else  if (_crtk_command == "servo_jv") {
+            this->AddPublisherFromCommandWrite<prmVelocityJointSet, sensor_msgs::JointState>
                 (_interface_name, _command, _ros_topic);
         } else  if (_crtk_command == "servo_jf") {
             this->AddPublisherFromCommandWrite<prmForceTorqueJointSet, sensor_msgs::JointState>


### PR DESCRIPTION
Overall functionality fix:
mts_ros_crtk_bridge_required will now set up connections so that the following works correctly:
``` crtk_ros_bridge_required->Connect(); ```
This matches the behavior of mts_ros_crtk_bridge_provided and I believe was left out by mistake

Other addition:
servo_jv command from CISST prmVelocityJointSet to ROS sensor_msgs::JointState per the crtk convention