### PR TITLE
add support for servo_cv

### DIFF
--- a/cisst_ros_crtk/src/mts_ros_crtk_bridge_provided.cpp
+++ b/cisst_ros_crtk/src/mts_ros_crtk_bridge_provided.cpp
@@ -321,7 +321,11 @@ void mts_ros_crtk_bridge_provided::bridge_interface_provided(const std::string &
             } else if (_crtk_command == "servo_ci") {
                 m_subscribers_bridge->AddSubscriberToCommandWrite<prmCartesianImpedance, crtk_msgs::CartesianImpedance>
                     (_required_interface_name, _command, _ros_topic);
+            } else if (_crtk_command == "servo_cv") {
+                m_subscribers_bridge->AddSubscriberToCommandWrite<prmVelocityCartesianSet, geometry_msgs::TwistStamped>
+                    (_required_interface_name, _command, _ros_topic);
             }
+
         }
     }
 


### PR DESCRIPTION
Hi Anton,

After you got sawUniversalRobot working with the cisst_crtk_ros_bridge, we lost support for the servo_cv command we were using. The CRTK wiki doesn't list a ROS payload yet for this, but I think it's pretty clear it should be a TwistStamped (this is what that repo did manually before using the cisst ros bridge). 

Best,

Henry