### PR TITLE
Bug fix for dvrk_arm_from_ros

### DIFF
--- a/cisst_ros_bridge/include/cisst_ros_bridge/mtsROSBridge.h
+++ b/cisst_ros_bridge/include/cisst_ros_bridge/mtsROSBridge.h
@@ -993,7 +993,7 @@ public:
 protected:
     //! list of publishers
     typedef std::list<mtsROSPublisherBase *> publishers_t;
-    publishers_t m_publishers;
+    publishers_t m_periodic_publishers;
 
     //! ros node
     cisst_ral::node_ptr_t m_node;
@@ -1034,7 +1034,7 @@ bool mtsROSBridge::AddPublisherFromCommandRead(const std::string & interface_req
         delete new_pub;
         return false;
     }
-    m_publishers.push_back(new_pub);
+    m_periodic_publishers.push_back(new_pub);
     return true;
 }
 
@@ -1093,7 +1093,6 @@ bool mtsROSBridge::AddPublisherFromEventWrite(const std::string & interface_requ
         delete new_pub;
         return false;
     }
-    m_publishers.push_back(new_pub);
     return true;
 }
 

--- a/cisst_ros_bridge/include/cisst_ros_bridge/mtsROSBridge.h
+++ b/cisst_ros_bridge/include/cisst_ros_bridge/mtsROSBridge.h
@@ -1137,6 +1137,12 @@ bool mtsROSBridge::AddSubscriberToCommandRead(const std::string & interface_prov
     if (!interfaceProvided) {
         interfaceProvided = this->AddInterfaceProvided(interface_provided);
     }
+    if (!interfaceProvided) {
+        CISST_RAL_ERROR("mtsROSBridge::AddSubscriberToCommandRead: failed to create provided interface.");
+        CMN_LOG_CLASS_INIT_ERROR << "AddSubscriberToCommandRead: failed to create provided interface \""
+                                 << interface_provided << "\"" << std::endl;
+        return false;
+    }
 
     mtsROSSubscriberStateTable<_cisst_t, _ros_t> * new_sub
         = new mtsROSSubscriberStateTable<_cisst_t, _ros_t>(name, m_node, table_size);

--- a/cisst_ros_bridge/src/mtsROSBridge.cpp
+++ b/cisst_ros_bridge/src/mtsROSBridge.cpp
@@ -97,10 +97,10 @@ void mtsROSBridge::Configure(const std::string & CMN_UNUSED(filename))
 
 mtsROSBridge::~mtsROSBridge()
 {
-    for (auto pub : m_publishers) {
+    for (auto pub : m_periodic_publishers) {
         delete(pub);
     }
-    m_publishers.clear();
+    m_periodic_publishers.clear();
 }
 
 bool mtsROSBridge::AddIntervalStatisticsInterface(const std::string & interfaceName)
@@ -151,7 +151,7 @@ void mtsROSBridge::Run(void)
     ProcessQueuedCommands();
     ProcessQueuedEvents();
 
-    for (auto pub : m_publishers) {
+    for (auto pub : m_periodic_publishers) {
         pub->Execute();
     }
 
@@ -187,7 +187,6 @@ bool mtsROSBridge::AddPublisherFromEventVoid(const std::string & interfaceRequir
             delete new_pub;
             return false;
         }
-    m_publishers.push_back(new_pub);
     return true;
 }
 
@@ -215,7 +214,7 @@ bool mtsROSBridge::Addtf2BroadcasterFromCommandRead(const std::string & interfac
         delete new_pub;
         return false;
     }
-    m_publishers.push_back(new_pub);
+    m_periodic_publishers.push_back(new_pub);
     return true;
 }
 
@@ -239,7 +238,6 @@ bool mtsROSBridge::AddLogFromEventWrite(const std::string & interfaceRequiredNam
         delete new_pub;
         return false;
     }
-    m_publishers.push_back(new_pub);
     return true;
 }
 

--- a/cisst_ros_crtk/include/cisst_ros_crtk/mts_ros_crtk_bridge_required.h
+++ b/cisst_ros_crtk/include/cisst_ros_crtk/mts_ros_crtk_bridge_required.h
@@ -50,11 +50,6 @@ public:
 
     void init(void); // called by all ctors
     void Configure(const std::string & _json_file) override;
-    void ConfigureJSON(const Json::Value & _json_config);
-
-    inline void Startup(void) {};
-    void Run(void);
-    inline void Cleanup(void) {};
 
     /*! This method will look at all the required functions and event
       handlers that match the CRTK convention and automatically create

--- a/cisst_ros_crtk/src/mts_ros_crtk_bridge_provided.cpp
+++ b/cisst_ros_crtk/src/mts_ros_crtk_bridge_provided.cpp
@@ -505,11 +505,7 @@ void mts_ros_crtk_bridge_provided::bridge_interface_provided(const std::string &
                         (_required_interface_name, _command, _ros_topic);
                 }
             } else if (_crtk_command == "period_statistics") {
-                std::string _namespace = _component_name + "_" + _interface_name;
-                std::transform(_namespace.begin(), _namespace.end(), _namespace.begin(), tolower);
-                cisst_ral::clean_namespace(_namespace);
-                m_stats_bridge->AddIntervalStatisticsPublisher("stats/" + _namespace,
-                                                               _component_name, _interface_name);
+                m_stats_bridge->AddIntervalStatisticsPublisher(_clean_namespace_no_trailing_slash, _component_name, _interface_name);
             }
         }
     }

--- a/cisst_ros_crtk/src/mts_ros_crtk_bridge_required.cpp
+++ b/cisst_ros_crtk/src/mts_ros_crtk_bridge_required.cpp
@@ -40,12 +40,11 @@ mts_ros_crtk_bridge_required::mts_ros_crtk_bridge_required(const mtsTaskPeriodic
     cisst_ral::ral ral(arg.Name);
     m_node = ral.node();
     init();
+    PerformsSpin(true);
 }
 
 void mts_ros_crtk_bridge_required::init(void)
-{
-    PerformsSpin(true);
-}
+{ }
 
 mts_ros_crtk_bridge_required::~mts_ros_crtk_bridge_required(void)
 {

--- a/cisst_ros_crtk/src/mts_ros_crtk_bridge_required.cpp
+++ b/cisst_ros_crtk/src/mts_ros_crtk_bridge_required.cpp
@@ -200,7 +200,7 @@ void mts_ros_crtk_bridge_required::populate_interface_provided(const std::string
                 (_interface_name, _command, _ros_topic);
         } else if (_crtk_command == "period_statistics") {
             this->AddSubscriberToCommandRead<mtsIntervalStatistics, CISST_RAL_MSG(cisst_msgs, IntervalStatistics)>
-                (_interface_name, _command, "stats/" + _ros_topic);
+                (_interface_name, _command, _ros_topic);
         } else {
             CMN_LOG_CLASS_INIT_WARNING << "populate_interface_provided: read command \"" << _command
                                        << "\" is not recognized as a CRTK command so it was not automatically added to the provided interface \""

--- a/cisst_ros_crtk/src/mts_ros_crtk_bridge_required.cpp
+++ b/cisst_ros_crtk/src/mts_ros_crtk_bridge_required.cpp
@@ -44,6 +44,7 @@ mts_ros_crtk_bridge_required::mts_ros_crtk_bridge_required(const mtsTaskPeriodic
 
 void mts_ros_crtk_bridge_required::init(void)
 {
+    PerformsSpin(true);
 }
 
 mts_ros_crtk_bridge_required::~mts_ros_crtk_bridge_required(void)
@@ -64,17 +65,6 @@ void mts_ros_crtk_bridge_required::Configure(const std::string & _json_file)
     }
 
     ConfigureJSON(_json_config);
-}
-
-void mts_ros_crtk_bridge_required::ConfigureJSON(const Json::Value & _json_config)
-{
-    Json::Value _json_value;
-}
-
-void mts_ros_crtk_bridge_required::Run(void)
-{
-    ProcessQueuedCommands();
-    ProcessQueuedEvents();
 }
 
 void mts_ros_crtk_bridge_required::bridge_interface_required(const std::string & _component_name,
@@ -210,7 +200,7 @@ void mts_ros_crtk_bridge_required::populate_interface_provided(const std::string
                 (_interface_name, _command, _ros_topic);
         } else if (_crtk_command == "period_statistics") {
             this->AddSubscriberToCommandRead<mtsIntervalStatistics, CISST_RAL_MSG(cisst_msgs, IntervalStatistics)>
-                (_interface_name, _command, _ros_topic);
+                (_interface_name, _command, "stats/" + _ros_topic);
         } else {
             CMN_LOG_CLASS_INIT_WARNING << "populate_interface_provided: read command \"" << _command
                                        << "\" is not recognized as a CRTK command so it was not automatically added to the provided interface \""


### PR DESCRIPTION
Make sure mts_ros_crtk_bridge_required is spun so subscribers work. Tested and works for teleoperation on ROS2, but still needs to be tested on ROS1.

Also fixes period_statistics for dvrk_arm_from_ros by moving where the CRTK bridge provided publishes it to match where the bridge required is looking for it.